### PR TITLE
Fixed link for RSS tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ super-search
 
 I created this plugin to be used with a Jekyll blog. But it will work equally good with any blog having an RSS feed file. If you do not have one already, here are some easy ways to do it for your blog:
 
-- [RSS for Jekyll blog](http://joelglovier.com/writing/rss-for-jekyll/).
+- [RSS for Jekyll blog](http://joelglovier.com/writing/rss-for-jekyll).
 
 Demo
 -----


### PR DESCRIPTION
The link in README was giving an 404 due to an extra `/` at the end of URL.
